### PR TITLE
There's a new tag for tracking doc issues:  T-doc

### DIFF
--- a/_posts/2017-4-9-this-week-in-rust-docs-51.md
+++ b/_posts/2017-4-9-this-week-in-rust-docs-51.md
@@ -32,7 +32,7 @@ For now, here are the two big issues for Rust documentation:
 
 They all need help to move forward so any contribution is very welcome!
 
-There are currently around 70 other documentation issues opened. Look for [A-docs](https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AA-docs) tagged issues on GitHub!
+There are currently around 70 other documentation issues opened. Look for [T-doc](https://github.com/rust-lang/rust/labels/T-doc) tagged issues on GitHub!
 
 # Waiting for merge
 


### PR DESCRIPTION
I've changed the link for open documentation issues, as the old one wasn't working.