### PR TITLE
Fixed broken link in post 2018-4-22

### DIFF
--- a/_posts/2018-4-22-this-week-in-rust-docs-102.md
+++ b/_posts/2018-4-22-this-week-in-rust-docs-102.md
@@ -19,7 +19,7 @@ This week's edition was edited by [Guillaume Gomez](https://github.com/Guillaume
 
 # Latest news
 
-We added [settings into generated documentation](ttps://github.com/rust-lang/rust/pull/49954) so you can have your own setup. We'll add more options soon to make rust documentation browsing more personal and comfortable for everyone!
+We added [settings into generated documentation](https://github.com/rust-lang/rust/pull/49954) so you can have your own setup. We'll add more options soon to make rust documentation browsing more personal and comfortable for everyone!
 
 # Current opened issues
 


### PR DESCRIPTION
The "settings into generated documentation" link was broken, just required adding a character.